### PR TITLE
Make sure the builtin cd is used in libscala.sh

### DIFF
--- a/libscala.sh
+++ b/libscala.sh
@@ -19,7 +19,7 @@
 
 export PATH="$PATH:$LIBSCALA_HOME/bin"
 
-export libscalaRoot="$(cd "$(dirname $BASH_SOURCE)" && pwd)"
+export libscalaRoot="$(builtin cd "$(dirname $BASH_SOURCE)" && pwd)"
 [[ -f "$libscalaRoot/bash.d/boot" ]] && . "$libscalaRoot/bash.d/boot"
 
 export libscalaBash="$libscalaRoot/bash.d"


### PR DESCRIPTION
Shell namespace hygiene?

My cd is a shell function that makes a call to tree after calling
(builtin) cd, because life's too short to do it every time. I'm probably
not doing myself any favours, but I haven't had any fallout from it
before.
